### PR TITLE
Skip env key if it is BITRISEIO_PULL_REQUEST_REPOSITORY_URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,6 +82,10 @@ func main() {
 	log.Donef("- Done")
 }
 
+func isRepositoryUrl(key string) bool {
+	return strings.Compare(key, "BITRISEIO_PULL_REQUEST_REPOSITORY_URL") == 0
+}
+
 func isGenericKey(key string) bool {
 	return strings.HasPrefix(key, "BITRISEIO_") && strings.HasSuffix(key, "_URL")
 }
@@ -109,6 +113,10 @@ func getFiles() ([]file, error) {
 	for _, env := range os.Environ() {
 		key, value := splitEnv(env)
 
+		if isRepositoryUrl(key) {
+			continue	
+		}
+		
 		if !isGenericKey(key) {
 			continue
 		}


### PR DESCRIPTION
All the BITRISEIO_*_URL envs are treated as files to be downloaded. But this pattern is also found in the key `BITRISEIO_PULL_REQUEST_REPOSITORY_URL` set by Bitrise when the workflow is triggered by a Pull Request.

So skipping the file when the key is `BITRISEIO_PULL_REQUEST_REPOSITORY_URL` will prevent failure of the `generic-file-storage` step.