### PR TITLE
Update osenvfileprovider.go

### DIFF
--- a/genericfilestorage/osenvfileprovider.go
+++ b/genericfilestorage/osenvfileprovider.go
@@ -74,7 +74,6 @@ func (provider OsEnvFileProvider) shouldHandle(key, url string) bool {
 func (provider OsEnvFileProvider) isValidURL(key, rawURL string) bool {
 	parsedURL, err := url.ParseRequestURI(rawURL)
 	if err != nil {
-		log.Printf("Failed to parse URL: %s. %s", key, err.(*url.Error).Unwrap())
 		return false
 	}
 


### PR DESCRIPTION
bitrise step fails due to method Unwrap() called on *url.Error
# github.com/bitrise-steplib/steps-generic-file-storage/genericfilestorage
src/github.com/bitrise-steplib/steps-generic-file-storage/genericfilestorage/osenvfileprovider.go:77:66: err.(*url.Error).Unwrap undefined (type *url.Error has no field or method Unwrap)
ERRO[14:36:33] Step (generic-file-storage@0) failed: Failed to prepare the step for execution through the required toolkit (go), error: Failed to install package, error: exit status 2